### PR TITLE
Skip sudo-only setup when sudo is unavailable

### DIFF
--- a/run_once_00-install-packages.sh.tmpl
+++ b/run_once_00-install-packages.sh.tmpl
@@ -1,14 +1,20 @@
 {{ if eq .chezmoi.os "linux" -}}
 
 #!/bin/bash
-sudo ()
+run_with_sudo ()
 {
-    [[ $EUID = 0 ]] || set -- command sudo "$@"
-    "$@"
+    if [[ $EUID = 0 ]]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        command sudo "$@"
+    else
+        echo "Skipping (sudo unavailable): $*" >&2
+        return 0
+    fi
 }
 
-sudo apt-get update
-sudo apt-get install -y \
+run_with_sudo apt-get update
+run_with_sudo apt-get install -y \
     dnsutils \
     jo \
     netcat \

--- a/run_once_90-settings.sh.tmpl
+++ b/run_once_90-settings.sh.tmpl
@@ -1,14 +1,20 @@
 {{ if eq .chezmoi.os "linux" -}}
 #!/bin/bash
-sudo ()
+run_with_sudo ()
 {
-    [[ $EUID = 0 ]] || set -- command sudo "$@"
-    "$@"
+    if [[ $EUID = 0 ]]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        command sudo "$@"
+    else
+        echo "Skipping (sudo unavailable): $*" >&2
+        return 0
+    fi
 }
 
-echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf || \
-    sudo sysctl fs.inotify.max_user_watches=524288 ||:
-sudo sysctl -p ||:
+echo fs.inotify.max_user_watches=524288 | run_with_sudo tee -a /etc/sysctl.conf || \
+    run_with_sudo sysctl fs.inotify.max_user_watches=524288 ||:
+run_with_sudo sysctl -p ||:
 
 {{ end -}}
 

--- a/run_once_after_00-copy-aqua-to-workspace.sh.tmpl
+++ b/run_once_after_00-copy-aqua-to-workspace.sh.tmpl
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
 {{ if .remoteContainers -}}
-sudo cp ~/aqua.yaml /workspace
+run_with_sudo () {
+    if [[ $EUID = 0 ]]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        command sudo "$@"
+    else
+        echo "Skipping (sudo unavailable): $*" >&2
+        return 0
+    fi
+}
+
+cp ~/aqua.yaml /workspace 2>/dev/null || run_with_sudo cp ~/aqua.yaml /workspace
 {{ end -}}

--- a/run_once_before_00-install-essential-packages.sh.tmpl
+++ b/run_once_before_00-install-essential-packages.sh.tmpl
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 {{ if eq .chezmoi.os "linux" -}}
-sudo () {
-    [[ $EUID = 0 ]] || set -- command sudo "$@"
-    "$@"
+run_with_sudo () {
+    if [[ $EUID = 0 ]]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        command sudo "$@"
+    else
+        echo "Skipping (sudo unavailable): $*" >&2
+        return 0
+    fi
 }
 
-sudo apt-get update
-sudo apt-get install -y unzip wget
+run_with_sudo apt-get update
+run_with_sudo apt-get install -y unzip wget
 {{ end -}}


### PR DESCRIPTION
### Motivation
- Make setup scripts tolerant of environments where `sudo` is unavailable so non-root workflows (containers, limited CI, developer machines) don't fail.
- Avoid interactive sudo prompts by preferring root execution or passwordless sudo and otherwise skipping only the sudo-only steps to preserve later tasks.

### Description
- Add a `run_with_sudo` helper to replace the previous local `sudo()` wrapper that runs the given command as root, uses passwordless `sudo` when available, and logs-and-skips when neither is possible.
- Apply `run_with_sudo` to Linux package installation in `run_once_00-install-packages.sh.tmpl` and `run_once_before_00-install-essential-packages.sh.tmpl` by replacing `sudo apt-get ...` with `run_with_sudo apt-get ...`.
- Use `run_with_sudo` for sysctl changes in `run_once_90-settings.sh.tmpl` by piping to `run_with_sudo tee` and falling back to `run_with_sudo sysctl` when needed.
- For remote container `aqua.yaml` copy in `run_once_after_00-copy-aqua-to-workspace.sh.tmpl`, attempt a normal `cp` first and fall back to `run_with_sudo cp` if the direct copy fails.
- Changes touch four template files: `run_once_00-install-packages.sh.tmpl`, `run_once_before_00-install-essential-packages.sh.tmpl`, `run_once_after_00-copy-aqua-to-workspace.sh.tmpl`, and `run_once_90-settings.sh.tmpl`.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors, which passed. 
- Linted the changed templates with `sed '/{{/d' <template> | bash -n` for each modified file to validate shell syntax after removing Go template markers, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a502d76c24c832ba2dd406c835cef84)