### PR TITLE
Install starship into $HOME/.local/bin to avoid sudo

### DIFF
--- a/run_once_00-install-packages.sh.tmpl
+++ b/run_once_00-install-packages.sh.tmpl
@@ -48,8 +48,9 @@ EOF
 
 {{ end -}}
 
-if command -v starship >/dev/null 2>&1; then 
+if command -v starship >/dev/null 2>&1; then
     echo "starship already installed"
 else
-    sh -c "$(curl -fsSL https://starship.rs/install.sh)" -y -f
+    mkdir -p "$HOME/.local/bin"
+    sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- -y -f -b "$HOME/.local/bin"
 fi


### PR DESCRIPTION
### Motivation
- Ensure the Starship prompt can be installed into a user-writable location so the installer does not require `sudo` or system write access.

### Description
- Create `$HOME/.local/bin` if missing and invoke the Starship installer with `-b "$HOME/.local/bin"` so the binary is placed in the user-local bin directory while keeping the existing presence check.

### Testing
- Ran `git diff --check` and static shell checks with `bash -n install.sh run_once_03-install-aqua.sh run_after_00-install-aqua-packages.sh` and `bash -n <(sed '/{{/d' run_once_00-install-packages.sh.tmpl)`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50307f641c832b83313eb6c651df25)