### PR TITLE
Manage agent skill with chezmoi

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -9,6 +9,11 @@ type = "git-repo"
 url = "https://github.com/ingydotnet/git-subrepo.git"
 refreshPeriod = "168h"
 
+[".agents/skills/fd287c3133457c4fd8f5601d34aa817d"]
+type = "git-repo"
+url = "https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d.git"
+refreshPeriod = "168h"
+
 {{ if eq .chezmoi.os "linux" }}
 
 {{ $pueueVersion := "3.4.1" }}

--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ My [chezmoi](https://www.chezmoi.io/) configuration.
 ```shell
 sh -c "$(curl -fsLS https://chezmoi.io/get)" -- init --apply reiyw
 ```
+
+## Agent skills
+
+Agent skills are managed as chezmoi externals under `~/.agents/skills`. They are
+installed and refreshed automatically by `chezmoi apply`.


### PR DESCRIPTION
### Motivation

- Ensure agent skills from the provided Gist are automatically installed and refreshed via `chezmoi` so skills can be managed alongside dotfiles.

### Description

- Add a chezmoi external entry in `.chezmoiexternal.toml` to install the Gist under `~/.agents/skills/fd287c3133457c4fd8f5601d34aa817d` as a `git-repo` with `refreshPeriod = "168h"`.
- Document agent skills management in `README.md` explaining that skills are placed under `~/.agents/skills` and are installed/refreshed by `chezmoi apply`.
- Commit changes to the repository (branch `work`).

### Testing

- Ran `git diff --check` which succeeded with no issues.
- Committed the changes using `git commit` which completed successfully and left the working tree clean as shown by `git status --short --branch`.
- Attempted `git ls-remote https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d.git HEAD` to verify remote access but it failed due to the environment proxy returning HTTP 403, so remote fetch could not be validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c1dcce848832b8db05a557dc37ebf)