### PR TITLE
Add i-have-adhd skill as an external archive in .chezmoiexternal.toml

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -14,6 +14,13 @@ type = "git-repo"
 url = "https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d.git"
 refreshPeriod = "168h"
 
+[".agents/skills/i-have-adhd"]
+type = "archive"
+url = "https://github.com/ayghri/i-have-adhd/archive/refs/heads/main.tar.gz"
+refreshPeriod = "168h"
+stripComponents = 3
+include = ["i-have-adhd-main/skills/i-have-adhd/**"]
+
 {{ if eq .chezmoi.os "linux" }}
 
 {{ $pueueVersion := "3.4.1" }}


### PR DESCRIPTION
### Motivation
- Manage the `i-have-adhd` skill as an external dependency so it is pulled into `./agents/skills` by `chezmoi` and kept up to date.

### Description
- Add an `archive` entry for `".agents/skills/i-have-adhd"` in `.chezmoiexternal.toml` that fetches `https://github.com/ayghri/i-have-adhd/archive/refs/heads/main.tar.gz` with `refreshPeriod = "168h"`, `stripComponents = 3`, and `include = ["i-have-adhd-main/skills/i-have-adhd/**"]`.

### Testing
- No automated tests were run for this small configuration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a716a547764832bba71ffac8e5c795e)